### PR TITLE
fix typo which was breaking background page module loading

### DIFF
--- a/module.js
+++ b/module.js
@@ -382,7 +382,7 @@ function mine(js) {
 
   function $multilineEnding(char) {
     if (char === "/") return $start;
-    if (char === "*") return $multilingEnding;
+    if (char === "*") return $multilineEnding;
     return $multilineComment;
   }
 


### PR DESCRIPTION
this was throwing error when loading from a background page in a chrome extension.
